### PR TITLE
Introduce a 5s delay before opening the preview to give the server time to be ready

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,11 +2,12 @@ tasks:
   - init: npm install
     command: |
       export CLIENT_URL="$(gp url 35729)/livereload.js?snipver=1&port=443"
+      { gp await-port 5000 && sleep 5 && gp preview $(gp url 5000) & } &> /dev/null
       gp open src/App.svelte
       npm run dev
 ports:
   - port: 5000
-    onOpen: open-preview
+    onOpen: ignore
   - port: 35729
     onOpen: ignore
 vscode:


### PR DESCRIPTION
## Before

When you open https://gitpod.io/#https://github.com/gitpod-io/sveltejs-template, this is what you see:

<img width="1440" alt="Screenshot 2021-02-03 at 19 08 57" src="https://user-images.githubusercontent.com/599268/106790246-91d66e00-6653-11eb-8fcc-9fe9befe3b13.png">

## After

https://gitpod.io/#https://github.com/jankeromnes/sveltejs-template

<img width="1439" alt="Screenshot 2021-02-03 at 19 10 42" src="https://user-images.githubusercontent.com/599268/106790285-a155b700-6653-11eb-8f39-0944e9e8fc55.png">
